### PR TITLE
Update find statement for docker volumes

### DIFF
--- a/confs/global/init-lua.conf
+++ b/confs/global/init-lua.conf
@@ -67,7 +67,7 @@ end
 
 -- Load plugins
 ngx.shared.plugins_data:safe_set("plugins", nil, 0)
-local p = io.popen("find /plugins /opt/bunkerized-nginx/plugins/ -maxdepth 1 -mindepth 1 -type d")
+local p = io.popen("find /plugins /opt/bunkerized-nginx/plugins/ -maxdepth 1 -mindepth 1 -type d | sort -u")
 for dir in p:lines() do
 	-- read JSON
 	local file = io.open(dir .. "/plugin.json")

--- a/confs/global/init-lua.conf
+++ b/confs/global/init-lua.conf
@@ -67,7 +67,7 @@ end
 
 -- Load plugins
 ngx.shared.plugins_data:safe_set("plugins", nil, 0)
-local p = io.popen("find /opt/bunkerized-nginx/plugins -maxdepth 1 -type d ! -path /opt/bunkerized-nginx/plugins")
+local p = io.popen("find /plugins /opt/bunkerized-nginx/plugins/ -maxdepth 1 -mindepth 1 -type d")
 for dir in p:lines() do
 	-- read JSON
 	local file = io.open(dir .. "/plugin.json")


### PR DESCRIPTION
updated the use of find shell exec so it will not only find under /opt/ .. and  also under /plugins - AS STATED IN MANUALS !
docker container setup found nothing under /plugins
( also it did not find anything under /opt.. until changed to mindepth+maxdepth