### PR TITLE
Fix small typo in autoconf integration

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -241,7 +241,7 @@ docker run \
 Here is the docker-compose equivalent for the BunkerWeb autoconf stack :
 
 ```yaml
-version: '3'
+version: '3.5'
 
 services:
 


### PR DESCRIPTION
The autoconf integration had the version 3 but the version 3.5 is mandatory if we want to give names to networks.