### PR TITLE
Add support for arm + change scheduler python version

### DIFF
--- a/src/autoconf/Dockerfile
+++ b/src/autoconf/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /usr/share/bunkerweb/deps && \
     rm -rf /tmp/req
 
 # Install dependencies
-RUN apk add --no-cache --virtual .build-deps g++ gcc && \
+RUN apk add --no-cache --virtual .build-deps g++ gcc libffi-dev && \
     pip install --no-cache-dir --upgrade pip && \
     pip install wheel && \
     mkdir -p /usr/share/bunkerweb/deps/python && \

--- a/src/scheduler/Dockerfile
+++ b/src/scheduler/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.10-alpine
 
 # Copy python requirements
 COPY src/scheduler/requirements.txt /tmp/req/requirements.txt
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/share/bunkerweb/deps && \
   rm -rf /tmp/req
 
 # Install python requirements
-RUN apk add --no-cache --virtual .build-deps g++ gcc && \
+RUN apk add --no-cache --virtual .build-deps g++ gcc libffi-dev && \
   pip install --no-cache-dir --upgrade pip && \
   pip install wheel && \
   mkdir -p /usr/share/bunkerweb/deps/python && \

--- a/src/ui/Dockerfile
+++ b/src/ui/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p /usr/share/bunkerweb/deps && \
     rm -rf /tmp/req
 
 # Install python requirements
-RUN apk add --no-cache --virtual .build-deps g++ gcc && \
+RUN apk add --no-cache --virtual .build-deps g++ gcc libffi-dev && \
     pip install --no-cache-dir --upgrade pip && \
     pip install wheel && \
     mkdir -p /usr/share/bunkerweb/deps/python && \


### PR DESCRIPTION
Changed the scheduler python version because certbot doesn't yet support Python 3.11
([issue](https://github.com/certbot/certbot/issues/9441))