### PR TITLE
Update k8s.mariadb.ui.yml

### DIFF
--- a/misc/integrations/k8s.mariadb.ui.yml
+++ b/misc/integrations/k8s.mariadb.ui.yml
@@ -141,9 +141,10 @@ spec:
       labels:
         app: bunkerweb-scheduler
     spec:
+      serviceAccountName: sa-bunkerweb
       containers:
-        - name: bunkerweb-controller
-          image: bunkerity/bunkerweb-autoconf:1.4.6
+        - name: bunkerweb-scheduler
+          image: bunkerity/bunkerweb-scheduler:1.4.6
           imagePullPolicy: Always
           env:
             - name: KUBERNETES_MODE


### PR DESCRIPTION
Fixed  "serviceAccountName: sa-bunkerweb" missing in scheduler Deployment Fixed scheduler spec.containers.name "bunkerweb-scheduler" Fixed Wrong image for scheduler deployment "bunkerity/bunkerweb-autoconf:1.4.6" > "bunkerity/bunkerweb-scheduler:1.4.6"