### PR TITLE
Update k8s.mariadb.ui.yml

### DIFF
--- a/misc/integrations/k8s.mariadb.ui.yml
+++ b/misc/integrations/k8s.mariadb.ui.yml
@@ -236,7 +236,11 @@ spec:
             - name: "ADMIN_PASSWORD"
               value: "changeme"
             - name: "ABSOLUTE_URI"
-              value: "http://www.example.com/admin"
+              value: "http://www.example.com/admin/"
+            - name: KUBERNETES_MODE
+              value: "YES"
+            - name: "DATABASE_URI"
+              value: "mariadb+pymysql://bunkerweb:testor@svc-bunkerweb-db:3306/db"
 ---
 apiVersion: v1
 kind: Service
@@ -308,13 +312,13 @@ metadata:
   name: ingress
   annotations:
     bunkerweb.io/www.example.com_USE_UI: "yes"
-    bunkerweb.io/www.example.com_REVERSE_PROXY_HEADERS: "X-Script-Name /admin"
+    bunkerweb.io/www.example.com_REVERSE_PROXY_HEADERS_1: "X-Script-Name /admin"
 spec:
   rules:
     - host: www.example.com
       http:
         paths:
-          - path: /admin
+          - path: /admin/
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
Fixed variables d'env for ui deployment to access DB & "http://www.example.com/admin" > "http://www.example.com/admin/" 
Fixed ingress REVERSE_PROXY_HEADERS > REVERSE_PROXY_HEADERS_1 
Fixed path: /admin > path: /admin/