### PR TITLE
Update k8s.mariadb.ui.yml

### DIFF
--- a/misc/integrations/k8s.mariadb.ui.yml
+++ b/misc/integrations/k8s.mariadb.ui.yml
@@ -226,6 +226,7 @@ spec:
       labels:
         app: bunkerweb-ui
     spec:
+      serviceAccountName: sa-bunkerweb
       containers:
         - name: bunkerweb-ui
           image: bunkerity/bunkerweb-ui:1.5.0-beta


### PR DESCRIPTION
Fixed serviceaccountname: sa-bunkerweb missing in bunkerweb-ui for pod access