### PR TITLE
improve scheduler entrypoint

### DIFF
--- a/src/bw/entrypoint.sh
+++ b/src/bw/entrypoint.sh
@@ -3,8 +3,6 @@
 # shellcheck disable=SC1091
 . /usr/share/bunkerweb/helpers/utils.sh
 
-RESTART_INTERVAL_S=10
-
 shopt -s nullglob
 ascii_array=(/usr/share/bunkerweb/misc/*.ascii)
 shopt -u nullglob
@@ -50,17 +48,14 @@ echo -e "IS_LOADING=yes\nUSE_BUNKERNET=no\nSERVER_NAME=\nAPI_HTTP_PORT=${API_HTT
 python3 /usr/share/bunkerweb/gen/main.py --variables /tmp/variables.env
 
 # start nginx
-while : ; do
-	log "ENTRYPOINT" "ℹ️" "Starting nginx ..."
-	nginx -g "daemon off;" &
-	pid="$!"
-	# wait while nginx is running
+log "ENTRYPOINT" "ℹ️" "Starting nginx ..."
+nginx -g "daemon off;" &
+pid="$!"
+
+# wait while nginx is running
+wait "$pid"
+while [ -f "/var/run/bunkerweb/nginx.pid" ] ; do
 	wait "$pid"
-	# if we arrive here and the pid file still exists, it was not cleaned up and indicates a dirty exit (crash)
-	[[ -f "/var/run/bunkerweb/nginx.pid" ]] || break
-	rm -f "/var/run/bunkerweb/nginx.pid"
-	log "ENTRYPOINT" "❌" "Main nginx process unexpectedly died! Trying restart in ${RESTART_INTERVAL_S}s"
-	sleep ${RESTART_INTERVAL_S}
 done
 
 log "ENTRYPOINT" "ℹ️" "BunkerWeb stopped"

--- a/src/scheduler/entrypoint.sh
+++ b/src/scheduler/entrypoint.sh
@@ -46,12 +46,18 @@ if ! grep -q "Docker" /usr/share/bunkerweb/INTEGRATION ; then
 fi
 
 # execute jobs
-log "ENTRYPOINT" "ℹ️ " "Executing scheduler ..."
-/usr/share/bunkerweb/scheduler/main.py &
-pid="$!"
-wait "$pid"
-while [ -f /var/run/bunkerweb/scheduler.pid ] ; do
-    wait "$pid"
+while : ; do
+	log "ENTRYPOINT" "ℹ️ " "Executing scheduler ..."
+	/usr/share/bunkerweb/scheduler/main.py &
+	pid="$!"
+	wait "$pid"
+	if [ -f "/var/run/bunkerweb/scheduler.pid" ]; then
+		log "ENTRYPOINT" "❌" "Scheduler died unexpectedly!"
+		rm -f "/var/run/bunkerweb/scheduler.pid"
+	fi
+	[[ ! -f /var/tmp/bunkerweb/scheduler.healthy ]] || break
+	log "ENTRYPOINT" "❌" "Scheduler exited unexpectedly; restarting scheduler after 10s..."
+	sleep 10
 done
 
 if [ -f /var/tmp/bunkerweb/scheduler.healthy ] ; then

--- a/src/scheduler/entrypoint.sh
+++ b/src/scheduler/entrypoint.sh
@@ -3,6 +3,8 @@
 # shellcheck disable=SC1091
 . /usr/share/bunkerweb/helpers/utils.sh
 
+RESTART_INTERVAL_S=10
+
 # trap SIGTERM and SIGINT
 function trap_exit() {
 	# shellcheck disable=SC2317
@@ -56,8 +58,8 @@ while : ; do
 		rm -f "/var/run/bunkerweb/scheduler.pid"
 	fi
 	[[ ! -f /var/tmp/bunkerweb/scheduler.healthy ]] || break
-	log "ENTRYPOINT" "❌" "Scheduler exited unexpectedly; restarting scheduler after 10s..."
-	sleep 10
+	log "ENTRYPOINT" "❌" "Scheduler exited unexpectedly; restarting scheduler after ${RESTART_INTERVAL_S}s..."
+	sleep ${RESTART_INTERVAL_S}
 done
 
 if [ -f /var/tmp/bunkerweb/scheduler.healthy ] ; then


### PR DESCRIPTION
Fixes poorly defined behaviour when the scheduler main process crashes.

The original code uses `wait $pid` to wait until the `main.py` process exits. This means that if `/var/run/bunkerweb/scheduler.pid` still exists after `wait $pid` returns, the contained pid therein is per definition invalid. I.e. if we should assume that a clean exit of `main.py` means the pid file should have been cleaned up, its mere existence at this point indicates a crash of the process.

This PR fixes the logic issues and makes crashes visible in the logs. It additionally tries to restart a crashed process after a delay.

Possibly usage of the `/var/tmp/bunkerweb/scheduler.healthy` file can also be removed (if its only function was to check for crashes), and the entrypoint could be made a bit leaner still.

Bonus info: the scheduler process crashed silently (in a podman container) when memory was limited to `100M`, with `>= 150M` it appears to work.