### PR TITLE
improve bw/entrypoint.sh behaviour

### DIFF
--- a/src/bw/entrypoint.sh
+++ b/src/bw/entrypoint.sh
@@ -51,12 +51,12 @@ python3 /usr/share/bunkerweb/gen/main.py --variables /tmp/variables.env
 log "ENTRYPOINT" "ℹ️" "Starting nginx ..."
 nginx -g "daemon off;" &
 pid="$!"
-
 # wait while nginx is running
 wait "$pid"
-while [ -f "/var/run/bunkerweb/nginx.pid" ] ; do
-	wait "$pid"
-done
+if [ -f "/var/run/bunkerweb/nginx.pid" ]; then # process $pid exited but didn't cleanup pid file => crash?
+	log "ENTRYPOINT" "❌" "Main nginx process exited uncleanly! Stopping BunkerWeb..."
+	exit 1
+fi
 
 log "ENTRYPOINT" "ℹ️" "BunkerWeb stopped"
 exit 0


### PR DESCRIPTION
Remove infinite restart-loop with incorrect condition; make container exit with rc 1 if main nginx exits uncleanly.

I'm not 100% sure whether this leads to the desired behaviour yet (should be tested).

**Before**: if the `nginx` process crashes, `wait $pid` stops blocking, but the crashed proces doesn't cleanup  the `pid` file so the `while` loop does nothing and causes 100% load.

**After**: if the main `nginx` proces exits _without cleaning up the pid file_, it is considered an unclean/unexpected  exit and causes the stale pid file to be cleaned up by the entrypoint and the container exiting with status 1.

However: if the container orchestrator is configured to restart containers on failure, this would cause a new `bw` instance to be started, so far so good. _BUT_: will this newly started container request the needed configs from the scheduler upon startup? Or is configuring "push only" (scheduler -> bw)? In the latter case we still have a problem.