### PR TITLE
[DOCS] add comment to ALLOWED_METHODS section about enabling HTTP POST

### DIFF
--- a/docs/security-tuning.md
+++ b/docs/security-tuning.md
@@ -41,7 +41,9 @@ STREAM support :x:
 
 You can control the allowed HTTP methods by listing them (separated with "|") in the `ALLOWED_METHODS` setting (default : `GET|POST|HEAD`). Clients sending a method which is not listed will get a "405 - Method Not Allowed".
 
-Note that if `POST` is required, then `OPTIONS` should also be specified to allow for the CORS pre-flight request.
+!!! note Using POST
+
+    If `POST` is required, then `OPTIONS` should also be specified to allow for the CORS pre-flight request.
 
 ### Max sizes
 

--- a/docs/security-tuning.md
+++ b/docs/security-tuning.md
@@ -41,6 +41,8 @@ STREAM support :x:
 
 You can control the allowed HTTP methods by listing them (separated with "|") in the `ALLOWED_METHODS` setting (default : `GET|POST|HEAD`). Clients sending a method which is not listed will get a "405 - Method Not Allowed".
 
+Note that if `POST` is required, then `OPTIONS` should also be specified to allow for the CORS pre-flight request.
+
 ### Max sizes
 
 STREAM support :x:


### PR DESCRIPTION
## Issue

- The `ALLOWED_METHODS` variable is a bit hidden in the settings, under `Miscellaneous` https://docs.bunkerweb.io/latest/settings/#miscellaneous
- The default of `GET|POST|HEAD` is understandably very strict, as many users may run bunkerweb in front of simple applications that only serve content.
- Application developers using bunkerweb in front of their apps will most likely need `POST` (amonst others like `PATCH`, `DELETE`, etc).
- A HTTP `POST` require actually requires two requests from browsers:
  - A CORS pre-flight request using `OPTIONS` first.
  - Then the `POST` request if CORS doesn't fail.

## Solution

- Added a small note in the docs `ALLOWED_METHODS`, located: https://docs.bunkerweb.io/latest/security-tuning/#allowed-methods:

```
Note that if `POST` is required, then `OPTIONS` should also be specified to allow for the CORS pre-flight request.
```

## Notes

- It's probably possible to enable `OPTIONS` by default if `POST` is included, but this is probably a bad idea.
- Options should be defined explicitly rather than implicitly.
- Feel free to close if you feel this requirement is obvious. I thought it might help prevent silly mistakes (like I made during first configuration!).
- Also, a separate issue, but I'm on a pretty bad internet connection these days & it took me forever to clone the >100mb `main` branch! I wonder if this large size is necessary for something, or perhaps the git history could be cleaned up a bit.