### PR TITLE
fix ngx_slab_alloc() failed: no memory for arm64 linux rpi pagesize 16k

### DIFF
--- a/src/common/confs/init-worker-lua.conf
+++ b/src/common/confs/init-worker-lua.conf
@@ -1,4 +1,4 @@
-lua_shared_dict worker_lock 16k;
+lua_shared_dict worker_lock {{ WORKERLOCK_MEMORY_SIZE }};
 
 init_worker_by_lua_block {
 	-- Libs

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -117,6 +117,15 @@
     "regex": "^(?! )(( *[^ ]+)(?!.*\\2))*$",
     "type": "text"
   },
+  "WORKERLOCK_MEMORY_SIZE": {
+    "context": "global",
+    "default": "48k",
+    "help": "Size of lua_shared_dict for initialization workers",
+    "id": "workerlock-memory-size",
+    "label": "Initialization Workerlock memory size",
+    "regex": "^\\d+[kKmMgG]?$",
+    "type": "text"
+  },
   "DATASTORE_MEMORY_SIZE": {
     "context": "global",
     "default": "64m",


### PR DESCRIPTION
Increase initialization lua_shared_dict size to 48k

Fixes `ngx_slab_alloc() failed: no memory` error for users running the `bunkerweb:1.5.10` docker container

Environment
```
Raspberry Pi 5 4GB
Operating System: Debian GNU/Linux 12 (bookworm)
Kernel: Linux 6.6.36-v8-16k+
Architecture: arm64
```

Before change
```
bunkerweb-1     | [2024-09-25 XXXX +0000] [GENERATOR] [12] [ℹ️ ] - Generator successfully executed !
bunkerweb-1     | [2024-09-25 XXXX] - ENTRYPOINT - ℹ️ - Starting nginx ...
bunkerweb-1     | 2024/09/25 XXXX [notice] 49#49: ModSecurity-nginx v1.0.3 (rules loaded inline/local/remote: 0/0/0)
bunkerweb-1     | 2024/09/25 XXXX [crit] 49#49: ngx_slab_alloc() failed: no memory
bunkerweb-1     | nginx: [crit] ngx_slab_alloc() failed: no memory
...
container crashes
```

After change
```
bunkerweb-1     | [2024-09-25 XXXX +0000] [GENERATOR] [14] [ℹ️ ] - Generator successfully executed !
bunkerweb-1     | [2024-09-25 XXXX] - ENTRYPOINT - ℹ️ - Starting nginx ...
bunkerweb-1     | 2024/09/25 XXXX [notice] 51#51: ModSecurity-nginx v1.0.3 (rules loaded inline/local/remote: 0/0/0)
bunkerweb-1     | 2024/09/25 XXXX [notice] 51#51: [INIT] init phase started
bunkerweb-1     | 2024/09/25 XXXX [notice] 51#51: [INIT] deleting old keys from datastore ...
bunkerweb-1     | 2024/09/25 XXXX [notice] 51#51: [INIT] deleted old keys from datastore
bunkerweb-1     | 2024/09/25 XXXX [notice] 51#51: [INIT] saving plugins into datastore ...
bunkerweb-1     | 2024/09/25 XXXX [notice] 51#51: [INIT] loaded plugin redirect v1.0
bunkerweb-1     | 2024/09/25 XXXX [notice] 51#51: [INIT] loaded plugin pro v1.0
bunkerweb-1     | 2024/09/25 XXXX [notice] 51#51: [INIT] loaded plugin realip v1.
....
... [notice] 51#51: start worker process 59
```

❤️ to Théophile and Florian for both being super knowledgeable and responsive in chat in helping narrow in on the fix! They are a 💪 Team