### PR TITLE
make warnings unique

### DIFF
--- a/src/autoconf/IngressController.py
+++ b/src/autoconf/IngressController.py
@@ -17,6 +17,7 @@ class IngressController(Controller):
         config.load_incluster_config()
         self.__corev1 = client.CoreV1Api()
         self.__networkingv1 = client.NetworkingV1Api()
+        self.unique_warnings = unique_warnings if unique_warnings is not None else []
 
     def _get_controller_instances(self) -> list:
         return [
@@ -95,11 +96,14 @@ class IngressController(Controller):
                         "Ignoring unsupported ingress rule without backend service port.",
                     )
                     continue
-                elif not path.backend.service.port.number:
-                    self._logger.warning(
-                        "Ignoring unsupported ingress rule without backend service port number.",
-                    )
-                    continue
+                elif path.backend.service.port.number is None:
+                        if path.backend.service.name not in self.unique_warnings:
+                            self._logger.warning(
+                                "Ignoring unsupported ingress rule without backend service port number for service %s.",
+                                path.backend.service.name
+                            )
+                            self.unique_warnings.append(path.backend.service.name)
+                        continue
 
                 service_list = self.__corev1.list_service_for_all_namespaces(
                     watch=False,


### PR DESCRIPTION
In a kubernetes environnement, when deploying the application following the documentation and while everything works fine in the cluster side, meaning that all pods are up, evrything works fine, etc... 

i've added a parameter which should be an empty list to the constructor, this is used to make warnings or error messages unique in the pods logs, instead of having the same log line repeat itself infinitely, the problem i had in my case is that there are some ingresses that point to a port name instead of port number, and when _to_services function does not find a valid port number it logs the line as a "Ignoring unsupported ingress rule without backend service port number."
the test i've added check if the service name is already present on the list, otherwise it appends it and logs it for one time, because the next time it'll be present in the list ( this is obviously clear :) ).

We can discuss to provide you with other informations if needed.

Regards