### PR TITLE
added three environment variables

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -42,6 +42,10 @@ STREAM support :warning:
 |`AUTOCONF_MODE`               |`no`                                                                                                                    |global   |no      |Enable Autoconf Docker integration.                                                         |
 |`SWARM_MODE`                  |`no`                                                                                                                    |global   |no      |Enable Docker Swarm integration.                                                            |
 |`KUBERNETES_MODE`             |`no`                                                                                                                    |global   |no      |Enable Kubernetes integration.                                                              |
+
+|`API_TIMEOUT`                 |`10`                                                                                                                   |global   |no      |Manually set the timeout for BunkerWeb API requests.                               |                                                      |
+|`API_READ_TIMEOUT`            |`30`                                                                                                                   |global   |no      |Manually set the read timeout for BunkerWeb API requests.                                |
+
 |`SERVER_TYPE`                 |`http`                                                                                                                  |multisite|no      |Server type : http or stream.                                                               |
 |`LISTEN_STREAM`               |`yes`                                                                                                                   |multisite|no      |Enable listening for non-ssl (passthrough).                                                 |
 |`LISTEN_STREAM_PORT`          |`1337`                                                                                                                  |multisite|no      |Listening port for non-ssl (passthrough).                                                   |
@@ -51,7 +55,7 @@ STREAM support :warning:
 |`IS_DRAFT`                    |`no`                                                                                                                    |multisite|no      |Internal use : set to yes when the service is in draft mode.                                |
 |`TIMERS_LOG_LEVEL`            |`debug`                                                                                                                 |global   |no      |Log level for timers.                                                                       |
 |`OVERRIDE_INSTANCES`          |                                                                                                                        |global   |no      |List of BunkerWeb instances separated with spaces (format : fqdn-or-ip:5000 fqdn-or-ip:5000)|
-
+|`DISABLE_CONFIGURATION_TESTING`                     |`no`                                                                                                                   |global   |no      |Disable sanity checks for all other environment variables.                                                      |
 
 ## Antibot
 

--- a/src/common/api/API.py
+++ b/src/common/api/API.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from os import environ
 from typing import Literal, Optional, Union
 from requests import request
 
@@ -25,7 +26,8 @@ class API:
         url: str,
         data: Optional[Union[dict, bytes]] = None,
         files=None,
-        timeout=(10, 30),
+        timeout=(int(environ.get('API_TIMEOUT', 10)), 
+                 int(environ.get('API_READ_TIMEOUT', 30))),
     ) -> tuple[bool, str, Optional[int], Optional[dict]]:
         try:
             kwargs = {}


### PR DESCRIPTION
API_TIMEOUT: determines the timeout for BunkerWeb API calls. useful if the API is accessed through bad or unstable links.
API_READ_TIMEOUT: determines the read timeout for BunkerWeb API calls. since the nginx configuration must be tested before the server responds to the API call, a configuration large enough simply prevents BunkerWeb from ever working without this value changed.
DISABLE_CONFIGURATION_TESTING: disables all regex testing for all configuration variables. sometimes the regexes are simply too strict and sanity checks fail for some valid configurations, especially involving permission policies and feature policies. this way, we can at least give a way for people to ignore the checks.