### PR TITLE
add important resource to the authorized list

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -812,7 +812,7 @@ metadata:
   name: cr-bunkerweb
 rules:
   - apiGroups: [""]
-    resources: ["services", "pods", "configmaps", "secrets"]
+    resources: ["services", "pods", "pods/log", "configmaps", "secrets"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]


### PR DESCRIPTION
it is mandatory to have this resource added to the list of authorized resources in order for the bunkerweb uito be able to reach the logs of all bunkerweb pods logs. if not, you'll have an error saying something like:

```
[2025-01-21 15:58:49 +0000] [UI] [9] [❌] - Could not get logs for pod bunkerweb-47r7n
Traceback (most recent call last):
  File "/usr/share/bunkerweb/ui/main.py", line 2081, in logs_container
    kubernetes_logs = kubernetes_client.read_namespaced_pod_log(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/bunkerweb/deps/python/kubernetes/client/api/core_v1_api.py", line 23957, in read_namespaced_pod_log
    return self.read_namespaced_pod_log_with_http_info(name, namespace, **kwargs)  # noqa: E501
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/bunkerweb/deps/python/kubernetes/client/api/core_v1_api.py", line 24076, in read_namespaced_pod_log_with_http_info
    return self.api_client.call_api(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/bunkerweb/deps/python/kubernetes/client/api_client.py", line 348, in call_api
    return self.__call_api(resource_path, method,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/bunkerweb/deps/python/kubernetes/client/api_client.py", line 180, in __call_api
    response_data = self.request(
                    ^^^^^^^^^^^^^
  File "/usr/share/bunkerweb/deps/python/kubernetes/client/api_client.py", line 373, in request
    return self.rest_client.GET(url,
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/bunkerweb/deps/python/kubernetes/client/rest.py", line 244, in GET
    return self.request("GET", url,
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/bunkerweb/deps/python/kubernetes/client/rest.py", line 238, in request
    raise ApiException(http_resp=r)
kubernetes.client.exceptions.ApiException: (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Audit-Id': '9c1fde7f-3259-4e67-bca0-14ecd88eb62a', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'Date': 'Tue, 21 Jan 2025 15:58:49 GMT', 'Content-Length': '339'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"bunkerweb-47r7n\" is forbidden: User \"system:serviceaccount:bunkerweb:sa-bunkerweb\" cannot get resource \"pods/log\" in API group \"\" in the namespace \"bunkerweb\"","reason":"Forbidden","details":{"name":"bunkerweb-47r7n","kind":"pods"},"code":403}
```

the last line says it clearly, the service account does not have the right to get the logs of pods:

**HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"bunkerweb-47r7n\" is forbidden: User \"system:serviceaccount:bunkerweb:sa-bunkerweb\" cannot get resource \"pods/log\" in API group \"\" in the namespace \"bunkerweb\"","reason":"Forbidden","details":{"name":"bunkerweb-47r7n","kind":"pods"},"code":403}**
