### PR TITLE
doc: fix pro url

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -3671,7 +3671,7 @@ The Pro plugin bundles advanced features and enhancements for enterprise deploym
 
 Follow these steps to configure and use the Pro features:
 
-1. **Obtain a license key:** Purchase a Pro license from the [BunkerWeb Panel](https://panel.bunkerweb.io/order/bunkerweb-pro?utm_campaign=self&utm_source=doc).
+1. **Obtain a license key:** Purchase a Pro license from the [BunkerWeb Panel](https://panel.bunkerweb.io/store/bunkerweb-pro?utm_campaign=self&utm_source=doc).
 2. **Configure your license key:** Use the `PRO_LICENSE_KEY` setting to configure your license.
 3. **Let BunkerWeb handle the rest:** Once configured with a valid license, Pro plugins are automatically downloaded and activated.
 4. **Monitor your Pro status:** Check the health indicators in the [web UI](web-ui.md) to confirm your Pro subscription status.

--- a/src/common/core/pro/README.md
+++ b/src/common/core/pro/README.md
@@ -20,7 +20,7 @@ The Pro plugin bundles advanced features and enhancements for enterprise deploym
 
 Follow these steps to configure and use the Pro features:
 
-1. **Obtain a license key:** Purchase a Pro license from the [BunkerWeb Panel](https://panel.bunkerweb.io/order/bunkerweb-pro?utm_campaign=self&utm_source=doc).
+1. **Obtain a license key:** Purchase a Pro license from the [BunkerWeb Panel](https://panel.bunkerweb.io/store/bunkerweb-pro?utm_campaign=self&utm_source=doc).
 2. **Configure your license key:** Use the `PRO_LICENSE_KEY` setting to configure your license.
 3. **Let BunkerWeb handle the rest:** Once configured with a valid license, Pro plugins are automatically downloaded and activated.
 4. **Monitor your Pro status:** Check the health indicators in the [web UI](web-ui.md) to confirm your Pro subscription status.

--- a/src/ui/app/templates/navbar.html
+++ b/src/ui/app/templates/navbar.html
@@ -76,7 +76,7 @@
                         <a class="btn btn-responsive btn-buy-now"
                            role="button"
                            aria-pressed="true"
-                           href="https://panel.bunkerweb.io/order/bunkerweb-pro?utm_campaign=self&utm_source=ui"
+                           href="https://panel.bunkerweb.io/store/bunkerweb-pro?utm_campaign=self&utm_source=ui"
                            target="_blank"
                            rel="noopener">
                             <span class="me-1 me-md-2 d-flex h-100 justify-content-center align-items-center">

--- a/src/ui/app/templates/pro.html
+++ b/src/ui/app/templates/pro.html
@@ -48,7 +48,7 @@
                                           data-i18n-options="{'pro_services': {{ pro_services }}}">Delete or draft some services to reach the number of {{ pro_services }} services.</span>
                                 </div>
                             {% endif %}
-                            <a href="{% if is_pro_version %}https://panel.bunkerweb.io/clientarea.php?action=services&utm_campaign=self&utm_source=ui{% else %}https://panel.bunkerweb.io/order/bunkerweb-pro?utm_campaign=self&utm_source=ui{% endif %}"
+                            <a href="{% if is_pro_version %}https://panel.bunkerweb.io/clientarea.php?action=services&utm_campaign=self&utm_source=ui{% else %}https://panel.bunkerweb.io/store/bunkerweb-pro?utm_campaign=self&utm_source=ui{% endif %}"
                                role="button"
                                aria-pressed="true"
                                class="btn btn-pro-now courier-prime"


### PR DESCRIPTION
Hi!

Could you check these URLs?
As I see the "order" part of it has been changed to "store".

At the bottom of https://panel.bunkerweb.io/ below PRODUCTS there are:
[BunkerWeb PRO](https://panel.bunkerweb.io/order/bunkerweb-pro)
[Support](https://panel.bunkerweb.io/order/support/1)
[Development](https://panel.bunkerweb.io/order/custom-services/4)
[Consulting](https://panel.bunkerweb.io/order/custom-services/5)

Not only the PRO url, but the others are also showing 404 to me now.
Sorry, I didn't know where the others should point at.

Best regards / Cordialement
