### PR TITLE
Fix support link in footer

### DIFF
--- a/src/ui/app/templates/footer.html
+++ b/src/ui/app/templates/footer.html
@@ -26,7 +26,7 @@
                    rel="noopener"
                    class="footer-link me-4"
                    data-i18n="footer.blog">Blog</a>
-                <a href="https://panel.bunkerweb.io/order/support?utm_campaign=self&utm_source=ui"
+                <a href="https://panel.bunkerweb.io/submitticket.php?utm_campaign=self&utm_source=ui"
                    target="_blank"
                    rel="noopener"
                    class="footer-link me-4"


### PR DESCRIPTION
The old link : https://panel.bunkerweb.io/order/support?utm_campaign=self&utm_source=ui, led to a 404 page
I fix it with the new url https://panel.bunkerweb.io/submitticket.php
