### PR TITLE
Update plugin.json - fix for SameSite = None

### DIFF
--- a/src/common/core/headers/plugin.json
+++ b/src/common/core/headers/plugin.json
@@ -48,7 +48,7 @@
       "help": "Cookie flags automatically added to all cookies (value accepted for nginx_cookie_flag_module).",
       "id": "cookie-flags",
       "label": "Cookie flags",
-      "regex": "^(\\*|[^\\s;]+)?(\\s*(([Ee]xpires)(?!.*\\4)=[^\\s;]+|([Dd]omain)(?!.*\\5)=[^\\s;]+|([Pp]ath)(?!.*\\6)=[^\\s;]+|[Hh]ttp[Oo]nly|[Ss]ame[Ss]ite(=([Ll]ax|[Ss]trict|[NN]one))?|[Ss]ecure)(?!.*\\3))*$",
+      "regex": "^(\\*|[^\\s;]+)?(\\s*(([Ee]xpires)(?!.*\\4)=[^\\s;]+|([Dd]omain)(?!.*\\5)=[^\\s;]+|([Pp]ath)(?!.*\\6)=[^\\s;]+|[Hh]ttp[Oo]nly|[Ss]ame[Ss]ite(=([Ll]ax|[Ss]trict|[Nn]one))?|[Ss]ecure)(?!.*\\3))*$",
       "type": "text",
       "multiple": "cookie-flags"
     },


### PR DESCRIPTION
The regex has a typo on Cookie Flags. If you look into square brackets of None, you will see NN instead of Nn. This could make the regex test fail