### PR TITLE
Fix safari issue

### DIFF
--- a/src/common/core/reverseproxy/confs/server-http/reverse-proxy.conf
+++ b/src/common/core/reverseproxy/confs/server-http/reverse-proxy.conf
@@ -64,6 +64,7 @@ add_header X-Proxy-Cache $upstream_cache_status;
 			{% set ws = all[k.replace("HOST", "WS")] if k.replace("HOST", "WS") in all else "" %}
 			{% set headers = all[k.replace("HOST", "HEADERS")] if k.replace("HOST", "HEADERS") in all else "" %}
 			{% set headers_client = all[k.replace("HOST", "HEADERS_CLIENT")] if k.replace("HOST", "HEADERS_CLIENT") in all else "" %}
+			{% set hide_headers = all[k.replace("HOST", "HIDE_HEADERS")] if k.replace("HOST", "HIDE_HEADERS") in all else "" %}
 			{% set buffering = all[k.replace("HOST", "BUFFERING")] if k.replace("HOST", "BUFFERING") in all else "yes" %}
 			{% set keepalive = all[k.replace("HOST", "KEEPALIVE")] if k.replace("HOST", "KEEPALIVE") in all else "yes" %}
 			{% set auth_request = all[k.replace("HOST", "AUTH_REQUEST")] if k.replace("HOST", "AUTH_REQUEST") in all else "" %}
@@ -115,6 +116,11 @@ location {{ url }} {
 			{% if headers_client != "" %}
 				{% for header_client in headers_client.split(";") %}
 	add_header {{ header_client }};
+				{% endfor %}
+			{% endif %}
+			{% if hide_headers != "" %}
+				{% for hide_header in hide_headers.split(" ") %}
+	proxy_hide_header {{ hide_header }};
 				{% endfor %}
 			{% endif %}
 	proxy_connect_timeout {{ connect_timeout }};

--- a/src/common/core/reverseproxy/plugin.json
+++ b/src/common/core/reverseproxy/plugin.json
@@ -83,6 +83,16 @@
       "type": "text",
       "multiple": "reverse-proxy"
     },
+    "REVERSE_PROXY_HIDE_HEADERS": {
+      "context": "multisite",
+      "default": "Upgrade",
+      "help": "List of HTTP headers to hide from clients when received from the proxied resource (values for proxy_hide_header directive).",
+      "id": "reverse-proxy-hide-headers",
+      "label": "Reverse proxy hide headers",
+      "regex": "^.*$",
+      "type": "text",
+      "multiple": "reverse-proxy"
+    },
     "REVERSE_PROXY_HEADERS_CLIENT": {
       "context": "multisite",
       "default": "",


### PR DESCRIPTION
Let's add a `REVERSE_PROXY_HIDE_HEADERS` setting with `Upgrade` value as default.

In theory it should not break existing production setup and fix the safari issue with backends sending `Upgrade` values.