### PR TITLE
ui: Allow to hide date and request id columns in reports table

### DIFF
--- a/src/ui/app/static/js/pages/reports.js
+++ b/src/ui/app/static/js/pages/reports.js
@@ -124,7 +124,7 @@ $(document).ready(function () {
   layout.topStart.buttons = [
     {
       extend: "colvis",
-      columns: "th:not(:nth-child(-n+1))",
+      columns: "th:not(:nth-child(-n+2))",
       text: `<span class="tf-icons bx bx-columns bx-18px me-md-2"></span><span class="d-none d-md-inline" data-i18n="button.columns">${t(
         "button.columns",
         "Columns",
@@ -235,7 +235,7 @@ $(document).ready(function () {
   const reports_config = {
     tableSelector: "#reports",
     tableName: "reports",
-    columnVisibilityCondition: (column) => column > 3 && column < 13,
+    columnVisibilityCondition: (column) => column > 2 && column < 13,
     dataTableOptions: {
       columnDefs: [
         { orderable: false, targets: -1 },

--- a/src/ui/app/utils.py
+++ b/src/ui/app/utils.py
@@ -74,6 +74,7 @@ COLUMNS_PREFERENCES_DEFAULTS = {
         "8": True,
     },
     "reports": {
+        "3": True,
         "4": True,
         "5": False,
         "6": True,


### PR DESCRIPTION
Hello Bunker team

With the introduction of the request id in the report table, it's getting hard to have all the useful informations without expanding each line.
I just added the missing "Date" and "Request ID" columns in the column visibility dropdown.

Another idea for the future : to be able to persist the column choices