### PR TITLE
Potential fix for code scanning alert no. 360: DOM text reinterpreted as HTML

### DIFF
--- a/src/ui/app/static/js/plugins-settings.js
+++ b/src/ui/app/static/js/plugins-settings.js
@@ -23,6 +23,15 @@ $(document).ready(() => {
     }
   };
 
+  // Escapes a string so it can be safely embedded as an HTML attribute value
+  function escapeAttr(str) {
+    return String(str)
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
   const $templateInput = $("#used-template");
   let usedTemplate = "low";
   if ($templateInput.length) {
@@ -2636,8 +2645,9 @@ $(document).ready(() => {
     let $hiddenInput = $dropdown.find('input[type="hidden"]');
     if ($hiddenInput.length === 0) {
       const settingName = $toggle.find(".multiselect-text").text();
+      // Escape the settingName to prevent XSS in attribute context
       $hiddenInput = $(
-        `<input type="hidden" name="${settingName}" class="plugin-setting">`,
+        `<input type="hidden" name="${escapeAttr(settingName)}" class="plugin-setting">`,
       );
       $dropdown.append($hiddenInput);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/bunkerity/bunkerweb/security/code-scanning/360](https://github.com/bunkerity/bunkerweb/security/code-scanning/360)

To fix this issue, we need to ensure that the value of `settingName` is safely escaped before being interpolated into the string for the `name` attribute in the `<input>` element. In JavaScript, a robust approach is to use a small function that escapes all characters with special meanings in HTML attribute values (for example, `"`, `'`, `&`, `<`, `>`, etc.). jQuery does not provide such a function out of the box, but we should avoid introducing dependencies. Therefore, we will define a utility function (such as `escapeAttr`) for this purpose within the same file. The fix applies only to line 2640.

**Steps:**
- Define an `escapeAttr` function above the place of usage. This function takes a string and returns it with HTML attribute meta-characters replaced with their respective entities.
- Use this function on `settingName` prior to interpolating it into the template literal for the input element’s `name` attribute.
- Only these lines need to be modified; no external packages are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
