### PR TITLE
changing wait timers to 0.25 sec

### DIFF
--- a/src/common/db/Database.py
+++ b/src/common/db/Database.py
@@ -261,6 +261,7 @@ class Database:
         current_time = datetime.now().astimezone()
         not_connected = True
         fallback = False
+        _db_connect_iters = 0
 
         while not_connected:
             try:
@@ -287,17 +288,18 @@ class Database:
                     _exit(1)
 
                 if any(error in str(e) for error in self.READONLY_ERROR):
-                    if log:
-                        self.logger.warning("The database is read-only. Retrying in read-only mode in 5 seconds ...")
+                    if log and _db_connect_iters % 8 == 0:
+                        self.logger.warning("The database is read-only. Retrying in read-only mode ...")
                     self.sql_engine.dispose(close=True)
                     self.sql_engine = create_engine(sqlalchemy_string, **self._engine_kwargs)
                     self.readonly = True
                 if "Unknown table" in str(e):
                     not_connected = False
                     continue
-                elif log:
-                    self.logger.warning("Can't connect to database, retrying in 5 seconds ...")
-                sleep(5)
+                elif log and _db_connect_iters % 8 == 0:
+                    self.logger.warning("Can't connect to database, retrying ...")
+                _db_connect_iters += 1
+                sleep(0.25)
             except BaseException as e:
                 self.logger.error(f"Error when trying to connect to the database: {e}")
                 exit(1)
@@ -739,7 +741,7 @@ class Database:
             except Exception as e:
                 if (datetime.now().astimezone() - current_time).total_seconds() > timeout_seconds:
                     raise e
-                sleep(1)
+                sleep(0.25)
 
         assert isinstance(meta_cls, sql_metadata)
 

--- a/src/scheduler/main.py
+++ b/src/scheduler/main.py
@@ -735,14 +735,17 @@ if __name__ == "__main__":
                 LOGGER.error("Config saver failed, configuration will not work as expected...")
 
         ready = False
+        _db_wait_iters = 0
         while not ready:
             db_metadata = SCHEDULER.db.get_metadata()
             if isinstance(db_metadata, str) or not db_metadata["is_initialized"]:
-                LOGGER.warning("Database is not initialized, retrying in 5s ...")
+                if _db_wait_iters % 8 == 0:
+                    LOGGER.warning("Database is not initialized, waiting ...")
+                _db_wait_iters += 1
             else:
                 ready = True
                 continue
-            sleep(5)
+            sleep(0.25)
 
         env = SCHEDULER.db.get_config()
         env["DATABASE_URI"] = SCHEDULER.db.database_uri
@@ -1193,9 +1196,12 @@ if __name__ == "__main__":
                     SCHEDULER.run_pending()
                     current_time = datetime.now().astimezone()
 
+                    _db_lock_iters = 0
                     while DB_LOCK_FILE.is_file() and DB_LOCK_FILE.stat().st_ctime + 30 > current_time.timestamp():
-                        LOGGER.debug("Database is locked, waiting for it to be unlocked (timeout: 30s) ...")
-                        sleep(1)
+                        if _db_lock_iters % 8 == 0:
+                            LOGGER.debug("Database is locked, waiting for it to be unlocked (timeout: 30s) ...")
+                        _db_lock_iters += 1
+                        sleep(0.25)
 
                     DB_LOCK_FILE.unlink(missing_ok=True)
 


### PR DESCRIPTION
unnecessary startup and recovery latency even when the waited condition resolved in milliseconds.

sleep(5) → sleep(0.25)
Log message throttled: only printed every 8 iterations (every 2 seconds)

Impact
Loop | Before | After | Worst-case reduction
-- | -- | -- | --
DB init poll | 5s per retry | 0.25s per retry | 4.75s per retry
DB connection retry | 5s per retry | 0.25s per retry | 4.75s per retry
DB schema reflection | 1s per retry | 0.25s per retry | 0.75s per retry
DB lock file poll | 1s per retry | 0.25s per retry | 0.75s per retry

