### PR TITLE
fix: read API_TOKEN from database in certbot hooks

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/bunkerity/bunkerweb",
+  "public_key": "pk_LvmBTDFeSHkvz22IYNQlv"
+}

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,0 @@
-{
-  "url": "https://context7.com/bunkerity/bunkerweb",
-  "public_key": "pk_LvmBTDFeSHkvz22IYNQlv"
-}

--- a/src/common/core/letsencrypt/jobs/certbot-auth.py
+++ b/src/common/core/letsencrypt/jobs/certbot-auth.py
@@ -22,11 +22,15 @@ try:
     validation = getenv("CERTBOT_VALIDATION", "")
     db = Database(LOGGER, sqlalchemy_string=getenv("DATABASE_URI"))
 
+    # Retrieve API_TOKEN from DB because certbot sanitizes the subprocess environment
+    # and strips non-CERTBOT_* variables, so getenv("API_TOKEN") is empty in hook context.
+    api_token = db.get_non_default_settings(global_only=True, filtered_settings=("API_TOKEN",)).get("API_TOKEN") or getenv("API_TOKEN")
+
     instances = db.get_instances()
 
     LOGGER.info(f"Sending challenge to {len(instances)} instances")
     for instance in instances:
-        api = API.from_instance(instance)
+        api = API.from_instance(instance, token=api_token)
         sent, err, status, resp = api.request("POST", "/lets-encrypt/challenge", data={"token": token, "validation": validation})
         if not sent:
             status = 1

--- a/src/common/core/letsencrypt/jobs/certbot-cleanup.py
+++ b/src/common/core/letsencrypt/jobs/certbot-cleanup.py
@@ -20,11 +20,15 @@ try:
     # Get env vars
     token = getenv("CERTBOT_TOKEN", "")
     db = Database(LOGGER, sqlalchemy_string=getenv("DATABASE_URI"))
+    # Retrieve API_TOKEN from DB because certbot sanitizes the subprocess environment
+    # and strips non-CERTBOT_* variables, so getenv("API_TOKEN") is empty in hook context.
+    api_token = db.get_non_default_settings(global_only=True, filtered_settings=("API_TOKEN",)).get("API_TOKEN") or getenv("API_TOKEN")
+
     instances = db.get_instances()
 
     LOGGER.info(f"Cleaning challenge from {len(instances)} instances")
     for instance in instances:
-        api = API.from_instance(instance)
+        api = API.from_instance(instance, token=api_token)
         sent, err, status, resp = api.request("DELETE", "/lets-encrypt/challenge", data={"token": token})
         if not sent:
             status = 1

--- a/src/common/core/letsencrypt/jobs/certbot-deploy.py
+++ b/src/common/core/letsencrypt/jobs/certbot-deploy.py
@@ -34,6 +34,10 @@ try:
 
     db = Database(LOGGER, sqlalchemy_string=getenv("DATABASE_URI"))
 
+    # Retrieve API_TOKEN from DB because certbot sanitizes the subprocess environment
+    # and strips non-CERTBOT_* variables, so getenv("API_TOKEN") is empty in hook context.
+    api_token = db.get_non_default_settings(global_only=True, filtered_settings=("API_TOKEN",)).get("API_TOKEN") or getenv("API_TOKEN")
+
     instances = db.get_instances()
     services = db.get_non_default_settings(global_only=True, methods=False, with_drafts=True, filtered_settings=("SERVER_NAME",))["SERVER_NAME"].split()
 
@@ -46,7 +50,7 @@ try:
     reload_min_timeout = int(reload_min_timeout)
 
     for instance in instances:
-        api = API.from_instance(instance)
+        api = API.from_instance(instance, token=api_token)
 
         sent, err, status, resp = api.request("POST", "/lets-encrypt/certificates", files=files)
         if not sent:


### PR DESCRIPTION
## Summary

- Certbot sanitizes subprocess environment, stripping `API_TOKEN` from certbot hook scripts (`certbot-auth.py`, `certbot-cleanup.py`, `certbot-deploy.py`)
- Hooks fail to authenticate with the BunkerWeb API, preventing certificate issuance/renewal
- Fix: retrieve `API_TOKEN` from the database via `db.get_non_default_settings()` (already available through `DATABASE_URI` which certbot preserves) instead of relying on `getenv("API_TOKEN")`

Fixes #3295

## Validation steps

1. Deploy BunkerWeb with `AUTO_LETS_ENCRYPT=yes` on a service
2. Trigger certificate issuance (add a new service or wait for renewal)
3. Verify in scheduler logs that the certbot hooks successfully authenticate and the certificate is issued
4. Verify that manual `certbot renew` also works correctly

## Files changed

- `src/common/core/letsencrypt/jobs/certbot-auth.py`
- `src/common/core/letsencrypt/jobs/certbot-cleanup.py`
- `src/common/core/letsencrypt/jobs/certbot-deploy.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)