### PR TITLE
fix: replace bare except clauses with except Exception (3 files)

### DIFF
--- a/src/autoconf/main.py
+++ b/src/autoconf/main.py
@@ -82,7 +82,7 @@ try:
     Path(sep, "var", "tmp", "bunkerweb", "autoconf.healthy").write_text("ok")
     LOGGER.info("Processing events ...")
     controller.process_events()
-except:
+except Exception:
     LOGGER.error(f"Exception while running autoconf :\n{format_exc()}")
     sys_exit(1)
 finally:

--- a/src/common/gen/save_config.py
+++ b/src/common/gen/save_config.py
@@ -248,7 +248,7 @@ if __name__ == "__main__":
                 LOGGER.error(f"An error occurred when setting the changes to checked in the database : {ret}")
     except SystemExit as e:
         sys_exit(e.code)
-    except:
+    except Exception:
         LOGGER.error(f"Exception while executing config saver : {format_exc()}")
         sys_exit(1)
 

--- a/src/common/utils/jobs.py
+++ b/src/common/utils/jobs.py
@@ -260,7 +260,7 @@ class Job:
 
             if ret and isinstance(file_cache, Path) and delete_file and file_cache != cache_path:
                 file_cache.unlink(missing_ok=True)
-        except:
+        except Exception:
             return False, f"exception :\n{format_exc()}"
         return ret, err
 
@@ -296,7 +296,7 @@ class Job:
 
         try:
             self.db.delete_job_cache(name, job_name=job_name, service_id=service_id)  # type: ignore
-        except:
+        except Exception:
             return False, f"exception :\n{format_exc()}"
         return ret, err
 


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` across 3 files (4 occurrences).

Per PEP 8, bare `except:` clauses should specify an exception type. Since none of these handlers re-raise the caught exception, `except Exception:` is the appropriate replacement — it catches all standard exceptions while still allowing `KeyboardInterrupt` and `SystemExit` to propagate normally.

**Files changed:**
- `src/autoconf/main.py` (1 occurrence)
- `src/common/utils/jobs.py` (2 occurrences)
- `src/common/gen/save_config.py` (1 occurrence)

**Change pattern:**
```python
# Before
except:
    return False, f"exception :\n{format_exc()}"

# After
except Exception:
    return False, f"exception :\n{format_exc()}"
```

## Testing
No behavior change for standard exceptions — `KeyboardInterrupt` and `SystemExit` will now propagate correctly instead of being silently caught.