### PR TITLE
Add support for configuring domains starting with a number via environment variables (by using `_` prefix)

### DIFF
--- a/src/common/gen/Configurator.py
+++ b/src/common/gen/Configurator.py
@@ -50,7 +50,7 @@ class Configurator:
         self.__compiled_regexes = {}
 
         # Pre-defined exclusion sets for config processing
-        self.__excluded_prefixes = ("_", "PYTHON", "KUBERNETES_", "SVC_", "LB_", "SUPERVISOR_")
+        self.__excluded_prefixes = ("PYTHON", "KUBERNETES_", "NOMAD_", "SVC_", "LB_", "SUPERVISOR_")
         self.__excluded_vars = frozenset(
             {
                 "DOCKER_HOST",
@@ -111,6 +111,12 @@ class Configurator:
             self.__variables = self.__load_variables(Path(variables))
         else:
             self.__variables = variables
+
+        """
+        NOTE: we now allow _1mthe1_... like (domain) variables to support domain names starting with a number.
+        This means we immediately trim off starting _ from variable names here.
+        """
+        self.__variables = {k.lstrip("_"): v for k, v in self.__variables.items()}
 
         self.__multisite = self.__variables.get("MULTISITE", "no") == "yes"
         self.__servers = self.__map_servers()

--- a/src/common/gen/Configurator.py
+++ b/src/common/gen/Configurator.py
@@ -117,14 +117,29 @@ class Configurator:
         # with a digit, e.g. 1nteresting.io).  Users write _1nteresting.io_USE_...
         # and we strip the single leading underscore here before any other processing.
         stripped: Dict[str, str] = {}
+        stripped_origins: Dict[str, str] = {}  # new_key -> original key that set the current value
         for k, v in self.__variables.items():
             new_key = k.removeprefix("_")
             if not new_key:
                 # Skip bare "_" or similar empty-after-strip keys
                 continue
             if new_key in stripped:
-                self.__logger.warning(f"Variable collision after stripping leading underscore: both {k!r} and {new_key!r} exist, keeping last value")
+                prev_key = stripped_origins[new_key]
+                # Deterministic tie-break: the explicit (non-underscore) key wins over the
+                # underscore-prefixed form, independent of dict iteration order, so the same
+                # input always yields the same output. In a collision exactly one of the two
+                # keys equals new_key (the explicit form); the other is "_" + new_key.
+                explicit_wins = k == new_key
+                winner = k if explicit_wins else prev_key
+                self.__logger.warning(
+                    f"Variable collision after stripping leading underscore: {prev_key!r} and {k!r} both map to {new_key!r}, keeping {winner!r}"
+                )
+                if explicit_wins:
+                    stripped[new_key] = v
+                    stripped_origins[new_key] = k
+                continue
             stripped[new_key] = v
+            stripped_origins[new_key] = k
         self.__variables = stripped
 
         self.__multisite = self.__variables.get("MULTISITE", "no") == "yes"

--- a/src/common/gen/Configurator.py
+++ b/src/common/gen/Configurator.py
@@ -112,11 +112,20 @@ class Configurator:
         else:
             self.__variables = variables
 
-        """
-        NOTE: we now allow _1mthe1_... like (domain) variables to support domain names starting with a number.
-        This means we immediately trim off starting _ from variable names here.
-        """
-        self.__variables = {k.lstrip("_"): v for k, v in self.__variables.items()}
+        # Allow a leading underscore prefix on env var names so that domain names
+        # starting with a digit can be configured (bash forbids var names starting
+        # with a digit, e.g. 1nteresting.io).  Users write _1nteresting.io_USE_...
+        # and we strip the single leading underscore here before any other processing.
+        stripped: Dict[str, str] = {}
+        for k, v in self.__variables.items():
+            new_key = k.removeprefix("_")
+            if not new_key:
+                # Skip bare "_" or similar empty-after-strip keys
+                continue
+            if new_key in stripped:
+                self.__logger.warning(f"Variable collision after stripping leading underscore: both {k!r} and {new_key!r} exist, keeping last value")
+            stripped[new_key] = v
+        self.__variables = stripped
 
         self.__multisite = self.__variables.get("MULTISITE", "no") == "yes"
         self.__servers = self.__map_servers()

--- a/src/common/gen/Configurator.py
+++ b/src/common/gen/Configurator.py
@@ -49,7 +49,7 @@ class Configurator:
         self.__compiled_regexes = {}
 
         # Pre-defined exclusion sets for config processing
-        self.__excluded_prefixes = ("_", "PYTHON", "KUBERNETES_", "SVC_", "LB_", "SUPERVISOR_")
+        self.__excluded_prefixes = ("PYTHON", "KUBERNETES_", "NOMAD_", "SVC_", "LB_", "SUPERVISOR_")
         self.__excluded_vars = frozenset(
             {
                 "DOCKER_HOST",
@@ -110,6 +110,12 @@ class Configurator:
             self.__variables = self.__load_variables(Path(variables))
         else:
             self.__variables = variables
+
+        """
+        NOTE: we now allow _1mthe1_... like (domain) variables to support domain names starting with a number.
+        This means we immediately trim off starting _ from variable names here.
+        """
+        self.__variables = {k.lstrip("_"): v for k, v in self.__variables.items()}
 
         self.__multisite = self.__variables.get("MULTISITE", "no") == "yes"
         self.__servers = self.__map_servers()

--- a/src/common/gen/Configurator.py
+++ b/src/common/gen/Configurator.py
@@ -111,11 +111,20 @@ class Configurator:
         else:
             self.__variables = variables
 
-        """
-        NOTE: we now allow _1mthe1_... like (domain) variables to support domain names starting with a number.
-        This means we immediately trim off starting _ from variable names here.
-        """
-        self.__variables = {k.lstrip("_"): v for k, v in self.__variables.items()}
+        # Allow a leading underscore prefix on env var names so that domain names
+        # starting with a digit can be configured (bash forbids var names starting
+        # with a digit, e.g. 1nteresting.io).  Users write _1nteresting.io_USE_...
+        # and we strip the single leading underscore here before any other processing.
+        stripped: Dict[str, str] = {}
+        for k, v in self.__variables.items():
+            new_key = k.removeprefix("_")
+            if not new_key:
+                # Skip bare "_" or similar empty-after-strip keys
+                continue
+            if new_key in stripped:
+                self.__logger.warning(f"Variable collision after stripping leading underscore: both {k!r} and {new_key!r} exist, keeping last value")
+            stripped[new_key] = v
+        self.__variables = stripped
 
         self.__multisite = self.__variables.get("MULTISITE", "no") == "yes"
         self.__servers = self.__map_servers()


### PR DESCRIPTION
Closes #1857 

Allows prefixing environment variables with `_` with the main purpose to allow (v)host/domain names starting with a number (e.g. `1mthe1.org` -> `_1mthe1.org_USE_LETS_ENCRYPT_WILDCARD="yes"`). 

The `_` prefix has been removed from the exclude prefixes list, but the `_` prefix is stripped from the variable name(s) as early as possible, so all further logic handles the server names etc. unchanged, i.e. as `1mthe1.org` in this example.

Also adds `NOMAD_` to the exluded prefixes list to make startup in nomad deployments less noisy.