### PR TITLE
fix: replace bare except with except Exception in autoconf

### DIFF
--- a/src/autoconf/main.py
+++ b/src/autoconf/main.py
@@ -82,7 +82,7 @@ try:
     Path(sep, "var", "tmp", "bunkerweb", "autoconf.healthy").write_text("ok")
     LOGGER.info("Processing events ...")
     controller.process_events()
-except:
+except Exception:
     LOGGER.error(f"Exception while running autoconf :\n{format_exc()}")
     sys_exit(1)
 finally:


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with `except Exception:` in `src/autoconf/main.py` (PEP 8 E722).

**Why:** Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`. Since this block logs the error and exits, `except Exception:` properly scopes it to application-level exceptions only.

**Change:**
```python
# Before (line 85)
except:
    LOGGER.error(f"Exception while running autoconf :\n{format_exc()}")

# After
except Exception:
    LOGGER.error(f"Exception while running autoconf :\n{format_exc()}")
```

## Testing
No behavior change for normal operation — only prevents accidentally swallowing system-level exceptions.