### PR TITLE
fix(gunicorn): parse DEBUG env var as a boolean

### DIFF
--- a/src/api/utils/gunicorn.conf.py
+++ b/src/api/utils/gunicorn.conf.py
@@ -16,7 +16,7 @@ for deps_path in [join(sep, "usr", "share", "bunkerweb", *paths) for paths in ((
 
 from biscuit_auth import KeyPair, PublicKey, PrivateKey
 
-from common_utils import effective_cpu_count, handle_docker_secrets  # type: ignore
+from common_utils import effective_cpu_count, getenv_bool, handle_docker_secrets  # type: ignore
 from logger import getLogger, log_types  # type: ignore
 
 from app.models.api_database import APIDatabase
@@ -120,7 +120,7 @@ max_requests_jitter = min(50, max_requests // 10)
 graceful_timeout = 30
 http_protocols = "h3,h2,h1"
 
-DEBUG = getenv("DEBUG", False)
+DEBUG = getenv_bool("DEBUG")
 
 loglevel = "debug" if DEBUG else LOG_LEVEL.lower()
 

--- a/src/common/utils/common_utils.py
+++ b/src/common/utils/common_utils.py
@@ -15,6 +15,10 @@ import logging
 PLUGIN_TAR_COMPRESS_LEVEL: int = 3
 
 
+def getenv_bool(name: str, default: str = "no") -> bool:
+    return getenv(name, default).strip().lower() in ("1", "true", "yes", "on")
+
+
 def handle_docker_secrets() -> Dict[str, str]:
     """Handle Docker secrets by reading from /run/secrets directory (Alpine only)"""
     secrets = {}

--- a/src/ui/utils/gunicorn.conf.py
+++ b/src/ui/utils/gunicorn.conf.py
@@ -18,7 +18,7 @@ for deps_path in [join(sep, "usr", "share", "bunkerweb", *paths) for paths in ((
 from biscuit_auth import KeyPair, PublicKey, PrivateKey
 from passlib.totp import generate_secret
 
-from common_utils import effective_cpu_count, handle_docker_secrets  # type: ignore
+from common_utils import effective_cpu_count, getenv_bool, handle_docker_secrets  # type: ignore
 from logger import getLogger, log_types  # type: ignore
 
 from app.models.ui_database import UIDatabase
@@ -120,7 +120,7 @@ max_requests_jitter = min(50, max_requests // 10)
 graceful_timeout = 30
 http_protocols = "h1"  # TODO: add h2 when fixed and h3 when supported
 
-DEBUG = getenv("DEBUG", False)
+DEBUG = getenv_bool("DEBUG")
 
 loglevel = "debug" if DEBUG else LOG_LEVEL.lower()
 

--- a/src/ui/utils/tmp-gunicorn.conf.py
+++ b/src/ui/utils/tmp-gunicorn.conf.py
@@ -7,7 +7,7 @@ for deps_path in [join(sep, "usr", "share", "bunkerweb", *paths) for paths in ((
     if deps_path not in sys_path:
         sys_path.append(deps_path)
 
-from common_utils import handle_docker_secrets  # type: ignore
+from common_utils import getenv_bool, handle_docker_secrets  # type: ignore
 from logger import getLogger, log_types  # type: ignore
 
 TMP_DIR = Path(sep, "var", "tmp", "bunkerweb")
@@ -29,7 +29,7 @@ FORWARDED_ALLOW_IPS = getenv(
 )
 PROXY_ALLOW_IPS = getenv("UI_PROXY_ALLOW_IPS", getenv("PROXY_ALLOW_IPS", FORWARDED_ALLOW_IPS))
 CAPTURE_OUTPUT = getenv("CAPTURE_OUTPUT", "no").lower() == "yes"
-DEBUG = getenv("DEBUG", False)
+DEBUG = getenv_bool("DEBUG")
 
 if CAPTURE_OUTPUT or "file" in log_types:
     errorlog = getenv("LOG_FILE_PATH", join(sep, "var", "log", "bunkerweb", "tmp-ui.log"))


### PR DESCRIPTION
Small fix, but pretty real.

`DEBUG` was read with raw `getenv(...)` in the API/UI Gunicorn configs. So `DEBUG=false` or `DEBUG=0` still turned debug mode on, because Python treats non-empty strings as truthy. Kinda sneaky.

Repro:
1. Set `DEBUG=false`
2. Load `src/ui/utils/tmp-gunicorn.conf.py`
3. Before this patch you get:
   - `DEBUG == "false"`
   - `daemon == True`
   - `loglevel == "debug"`
   - `reload` enabled

This path is actually live:
- `src/ui/entrypoint.sh` starts `utils/tmp-gunicorn.conf.py`
- `src/ui/entrypoint.sh` starts `utils/gunicorn.conf.py`
- `src/api/entrypoint.sh` starts `utils/gunicorn.conf.py`

After this patch, false-ish values stay off and true-ish values still work, all good.