### PR TITLE
fix(db): allow intentional deletion of all custom configs

### DIFF
--- a/src/api/app/routers/configs.py
+++ b/src/api/app/routers/configs.py
@@ -411,7 +411,7 @@ def delete_configs(req: ConfigsDeleteRequest) -> JSONResponse:
         return JSONResponse(status_code=404, content={"status": "error", "message": "No deletable UI/API configs found among selection", "skipped": skipped})
 
     for method, keep in keep_by_method.items():
-        err = db.save_custom_configs(keep, method)
+        err = db.save_custom_configs(keep, method, allow_empty=True)
         if err:
             return JSONResponse(status_code=500, content={"status": "error", "message": err, "skipped": skipped})
 

--- a/src/common/db/Database.py
+++ b/src/common/db/Database.py
@@ -2386,6 +2386,7 @@ class Database:
         changed: Optional[bool] = True,
         *,
         disable_cleanup: bool = False,
+        allow_empty: bool = False,
     ) -> str:
         """Save the custom configs in the database"""
         message = ""
@@ -2409,7 +2410,7 @@ class Database:
                 # actions delete rows individually through the UI/API, so by the time
                 # an empty payload reaches save_custom_configs there is nothing left
                 # to wipe and this guard is a no-op.
-                if method in ("ui", "api") and not custom_configs:
+                if method in ("ui", "api") and not custom_configs and not allow_empty:
                     existing_count = session.query(Custom_configs).filter(Custom_configs.method == method).count()
                     if existing_count > 0:
                         self.logger.warning(

--- a/src/ui/app/routes/configs.py
+++ b/src/ui/app/routes/configs.py
@@ -414,7 +414,7 @@ def configs_delete():
             return
 
         for method, configs_for_method in remaining_configs_by_method.items():
-            error = DB.save_custom_configs(configs_for_method, method)
+            error = DB.save_custom_configs(configs_for_method, method, allow_empty=True)
             if error:
                 DATA["TO_FLASH"].append({"content": f"An error occurred while saving the custom configs: {error}", "type": "error"})
                 DATA.update({"RELOADING": False, "CONFIG_CHANGED": False})


### PR DESCRIPTION
---

# Problem

Users cannot delete their last remaining custom configuration (e.g. a ModSecurity rule exception) through the Web UI or API.

When a user selects the only custom config and clicks delete, the UI shows a success message, but the config row persists in the database. Refreshing the page reveals the config is still there.

## Root Cause

The `save_custom_configs()` function in `src/common/db/Database.py` contains a data-loss guard (line 2412) that silently rejects empty payloads when rows still exist in the database:

```python
if method in ("ui", "api") and not custom_configs:
    existing_count = session.query(Custom_configs).filter(Custom_configs.method == method).count()
    if existing_count > 0:
        self.logger.warning(
            "Refusing save_custom_configs: incoming method={method!r} payload is empty while {existing_count} ..."
        )
        return message  # Silently returns — no error propagated
```

The delete flow builds a list of "remaining" configs after filtering out the selected ones. When the last config is deleted, this list is empty. The guard then blocks the save operation, but the caller receives no error — the row simply stays in the database.

The guard was designed to protect against accidental data loss (e.g. a service edit that lost its in-memory config map). However, the delete flow is an intentional deletion that legitimately produces an empty remaining list.

## Affected Code Paths

- **Web UI**: `src/ui/app/routes/configs.py` — `delete_configs()` function
- **REST API**: `src/api/app/routers/configs.py` — `delete_configs()` router endpoint

Both follow the same pattern: filter selected configs → call `save_custom_configs(remaining, method)` → guard blocks when `remaining` is empty.

---

# Fix

Add an explicit `allow_empty: bool = False` parameter to `save_custom_configs()`. The guard condition becomes:

```python
if method in ("ui", "api") and not custom_configs and not allow_empty:
```

The delete flows in both UI and API pass `allow_empty=True` to explicitly opt-in to empty payloads, while all other callers (scheduler, service edit, autoconf, `save_config`) keep the guard active by default.

## Files Changed

| File | Change |
|------|--------|
| `src/common/db/Database.py` | Add `allow_empty: bool = False` parameter; update guard condition |
| `src/ui/app/routes/configs.py` | Pass `allow_empty=True` in `delete_configs()` |
| `src/api/app/routers/configs.py` | Pass `allow_empty=True` in `delete_configs()` |

## Safety

- **Backward compatible**: `allow_empty=False` is the default. All existing callers are unaffected.
- **Explicit opt-in**: Only the delete flows pass `allow_empty=True`. They are the only callers that intentionally produce empty remaining lists.
- **Guard preserved**: Service edits, scheduler, autoconf, and `save_config.py` all continue to benefit from the data-loss protection.

---

# Validation

## Pre-commit checks

```
black --check src/common/db/Database.py src/ui/app/routes/configs.py src/api/app/routers/configs.py  # PASS
flake8 --max-line-length=160 --ignore=E266,E402,E501,E722,W503 ...  # PASS (no output)
refurb ...  # PASS (no output)
```

## Manual verification steps

1. Deploy a BunkerWeb instance with the Web UI
2. Create a single ModSecurity custom config (type: `MODSEC`, name: `exceptions`)
3. Select the config and click delete
4. Verify the config is actually removed from the database:
   ```
   sqlite3 /path/to/bunkerweb.db "SELECT COUNT(*) FROM bw_custom_configs WHERE method='ui';"
   -- Expected: 0 (was 1 before deletion)
   ```
5. Verify no configs remain after the operation

## Regression check

The guard still fires for all non-delete callers:
- Service edit with lost config map → guard blocks (expected)
- Scheduler saving manual configs → guard blocks if empty (expected)
- Autoconf with `disable_cleanup=True` → guard bypassed (existing behavior)
