### PR TITLE
fix(customcert): respect USE_CUSTOM_SSL=no in wildcard SNI fallback

### DIFF
--- a/src/common/core/customcert/customcert.lua
+++ b/src/common/core/customcert/customcert.lua
@@ -138,9 +138,9 @@ end
 function customcert:init()
 	local ret_ok, ret_err = true, "success"
 	local wildcard_certificates = {}
-	-- PATCH: hosts belonging to services that did not opt into custom SSL. The wildcard
-	-- SNI fallback must never serve a custom certificate for those, otherwise it shadows
-	-- the certificate another plugin (e.g. letsencrypt) would provide. See upstream bug.
+	-- Hosts of services that did not opt into custom SSL. The wildcard SNI fallback must never
+	-- serve a custom certificate for those, or it shadows the certificate another plugin
+	-- provides.
 	local wildcard_excluded = {}
 	if has_variable("USE_CUSTOM_SSL", "yes") then
 		local multisite, err = get_variable("MULTISITE", false)
@@ -154,7 +154,7 @@ function customcert:init()
 				return self:ret(false, "can't get USE_CUSTOM_SSL variables : " .. err)
 			end
 			for server_name, multisite_vars in pairs(vars) do
-				-- PATCH: remember every hostname of services that opted out of custom SSL
+				-- Remember every hostname of services that opted out of custom SSL
 				if multisite_vars["USE_CUSTOM_SSL"] ~= "yes" and server_name ~= "global" then
 					local opted_out = multisite_vars["SERVER_NAME"] or server_name
 					for key in opted_out:gmatch("%S+") do
@@ -207,32 +207,6 @@ function customcert:init()
 		ret_err = "custom cert is not used"
 	end
 
-	-- PATCH: the scoped variable store only holds settings that differ from the defaults,
-	-- so a service left at USE_CUSTOM_SSL=no may be absent from `vars` entirely. Derive the
-	-- remaining exclusions from the global SERVER_NAME list: every configured service that
-	-- has no exact custom certificate of its own must not be served a wildcard one.
-	if next(wildcard_certificates) then
-		local all_servers, servers_err = get_variable("SERVER_NAME", false)
-		if not all_servers then
-			-- Fail closed : without the global server list the exclusions would be incomplete,
-			-- so drop the wildcard fallback entirely rather than risk serving a custom
-			-- certificate to a service that opted out of custom SSL.
-			self.logger:log(
-				WARN,
-				"can't get SERVER_NAME variable, disabling custom certificate wildcard fallback : " .. servers_err
-			)
-			wildcard_certificates = {}
-		else
-			for key in all_servers:gmatch("%S+") do
-				local host = normalize_hostname(key)
-				local exact = self.internalstore:get("plugin_customcert_" .. host, true)
-				if not exact then
-					wildcard_excluded[host] = true
-				end
-			end
-		end
-	end
-
 	local ok, err = self.internalstore:set("plugin_customcert_wildcard_excluded", wildcard_excluded, nil, true)
 	if not ok then
 		return self:ret(false, "error while caching custom certificate wildcard exclusions : " .. err)
@@ -281,8 +255,8 @@ function customcert:ssl_certificate()
 		return self:ret(true, "certificate/key data found", data)
 	end
 
-	-- PATCH: never fall back to a wildcard custom certificate for a service that did not
-	-- enable custom SSL; let the next ssl_certificate plugin (letsencrypt) handle it.
+	-- Never fall back to a wildcard custom certificate for a service that did not enable custom
+	-- SSL : let the next ssl_certificate plugin handle it.
 	local excluded, excluded_err = self.internalstore:get("plugin_customcert_wildcard_excluded", true)
 	if not excluded and excluded_err ~= "not found" then
 		return self:ret(false, "can't get custom certificate wildcard exclusions : " .. excluded_err)

--- a/src/common/core/customcert/customcert.lua
+++ b/src/common/core/customcert/customcert.lua
@@ -212,8 +212,17 @@ function customcert:init()
 	-- remaining exclusions from the global SERVER_NAME list: every configured service that
 	-- has no exact custom certificate of its own must not be served a wildcard one.
 	if next(wildcard_certificates) then
-		local all_servers = get_variable("SERVER_NAME", false)
-		if all_servers then
+		local all_servers, servers_err = get_variable("SERVER_NAME", false)
+		if not all_servers then
+			-- Fail closed : without the global server list the exclusions would be incomplete,
+			-- so drop the wildcard fallback entirely rather than risk serving a custom
+			-- certificate to a service that opted out of custom SSL.
+			self.logger:log(
+				WARN,
+				"can't get SERVER_NAME variable, disabling custom certificate wildcard fallback : " .. servers_err
+			)
+			wildcard_certificates = {}
+		else
 			for key in all_servers:gmatch("%S+") do
 				local host = normalize_hostname(key)
 				local exact = self.internalstore:get("plugin_customcert_" .. host, true)

--- a/src/common/core/customcert/customcert.lua
+++ b/src/common/core/customcert/customcert.lua
@@ -138,6 +138,10 @@ end
 function customcert:init()
 	local ret_ok, ret_err = true, "success"
 	local wildcard_certificates = {}
+	-- PATCH: hosts belonging to services that did not opt into custom SSL. The wildcard
+	-- SNI fallback must never serve a custom certificate for those, otherwise it shadows
+	-- the certificate another plugin (e.g. letsencrypt) would provide. See upstream bug.
+	local wildcard_excluded = {}
 	if has_variable("USE_CUSTOM_SSL", "yes") then
 		local multisite, err = get_variable("MULTISITE", false)
 		if not multisite then
@@ -150,6 +154,13 @@ function customcert:init()
 				return self:ret(false, "can't get USE_CUSTOM_SSL variables : " .. err)
 			end
 			for server_name, multisite_vars in pairs(vars) do
+				-- PATCH: remember every hostname of services that opted out of custom SSL
+				if multisite_vars["USE_CUSTOM_SSL"] ~= "yes" and server_name ~= "global" then
+					local opted_out = multisite_vars["SERVER_NAME"] or server_name
+					for key in opted_out:gmatch("%S+") do
+						wildcard_excluded[normalize_hostname(key)] = true
+					end
+				end
 				if multisite_vars["USE_CUSTOM_SSL"] == "yes" and server_name ~= "global" then
 					local check, data = read_files({
 						"/var/cache/bunkerweb/customcert/" .. server_name .. "/cert.pem",
@@ -196,6 +207,28 @@ function customcert:init()
 		ret_err = "custom cert is not used"
 	end
 
+	-- PATCH: the scoped variable store only holds settings that differ from the defaults,
+	-- so a service left at USE_CUSTOM_SSL=no may be absent from `vars` entirely. Derive the
+	-- remaining exclusions from the global SERVER_NAME list: every configured service that
+	-- has no exact custom certificate of its own must not be served a wildcard one.
+	if next(wildcard_certificates) then
+		local all_servers = get_variable("SERVER_NAME", false)
+		if all_servers then
+			for key in all_servers:gmatch("%S+") do
+				local host = normalize_hostname(key)
+				local exact = self.internalstore:get("plugin_customcert_" .. host, true)
+				if not exact then
+					wildcard_excluded[host] = true
+				end
+			end
+		end
+	end
+
+	local ok, err = self.internalstore:set("plugin_customcert_wildcard_excluded", wildcard_excluded, nil, true)
+	if not ok then
+		return self:ret(false, "error while caching custom certificate wildcard exclusions : " .. err)
+	end
+
 	local wildcard_bases = {}
 	for base in pairs(wildcard_certificates) do
 		table.insert(wildcard_bases, base)
@@ -207,7 +240,7 @@ function customcert:init()
 		return #a > #b
 	end)
 
-	local ok, err = self.internalstore:set("plugin_customcert_wildcard_bases", wildcard_bases, nil, true)
+	ok, err = self.internalstore:set("plugin_customcert_wildcard_bases", wildcard_bases, nil, true)
 	if not ok then
 		return self:ret(false, "error while caching custom certificate wildcard bases : " .. err)
 	end
@@ -237,6 +270,16 @@ function customcert:ssl_certificate()
 		)
 	elseif data then
 		return self:ret(true, "certificate/key data found", data)
+	end
+
+	-- PATCH: never fall back to a wildcard custom certificate for a service that did not
+	-- enable custom SSL; let the next ssl_certificate plugin (letsencrypt) handle it.
+	local excluded, excluded_err = self.internalstore:get("plugin_customcert_wildcard_excluded", true)
+	if not excluded and excluded_err ~= "not found" then
+		return self:ret(false, "can't get custom certificate wildcard exclusions : " .. excluded_err)
+	end
+	if excluded and excluded[normalized_server_name] then
+		return self:ret(true, "custom certificate is not used (service did not enable USE_CUSTOM_SSL)")
 	end
 
 	local wildcard_bases, bases_err = self.internalstore:get("plugin_customcert_wildcard_bases", true)


### PR DESCRIPTION
### Summary

Fixes #3841.

The wildcard SNI fallback added in #3745 registers the wildcard SANs of **every** custom certificate as a global fallback and serves them for any matching SNI, without checking whether the requested service actually enabled `USE_CUSTOM_SSL`.

Since `customcert` runs before `letsencrypt` in the `ssl_certificate` phase, a service configured with `USE_CUSTOM_SSL=no` + `AUTO_LETS_ENCRYPT=yes` is served another service's custom certificate, and its own valid Let's Encrypt certificate is never used. Where the custom certificate is not publicly trusted — a Cloudflare Origin CA certificate, for instance — the affected sites present an untrusted certificate, and with HSTS there is no click-through, so they become unreachable. Nothing is logged when this happens.

### What changed

`src/common/core/customcert/customcert.lua`:

- `init()` records the hostnames of services that did **not** opt into custom SSL, and caches them as `plugin_customcert_wildcard_excluded`.
- Services left at the default `USE_CUSTOM_SSL=no` can be absent from the scoped variable store entirely, so the exclusion list is completed from the global `SERVER_NAME` list: every configured service without an exact custom certificate of its own.
- `ssl_certificate()` checks that list before falling back to a wildcard certificate, and returns without one for excluded services, letting `letsencrypt` (then `selfsigned`) handle the handshake.

An explicit `USE_CUSTOM_SSL=no` is treated as authoritative for that service. The fallback still applies to hosts that are **not** configured as services, so the behaviour #3745 introduced for `DISABLE_DEFAULT_SERVER=yes` setups is preserved.

### Validation

Running on a production instance with 56 services (Docker integration, `MULTISITE=yes`), mixing Cloudflare Origin certificates (`*.example.com` SAN, `USE_CUSTOM_SSL=yes`) with Let's Encrypt services (`USE_CUSTOM_SSL=no`, DNS challenge, wildcard).

- Before: 10 services with `USE_CUSTOM_SSL=no` were served the Cloudflare Origin certificate; browsers rejected them.
- After: all 56 services present the expected certificate — the 46 custom-SSL ones unchanged, the 10 others their Let's Encrypt certificate. Verified per host with `openssl s_client -servername <host>`.
- End-to-end with full chain verification: `curl -w '%{ssl_verify_result}'` returns `0` (was failing before), HTTP 200.
- A hostname that is *not* configured as a service still receives the wildcard custom certificate, confirming the original feature keeps working.
- `customcert:init()` reports success; no new log output or errors.

Linting, per `AGENTS.md`:

- StyLua 2.5.2 with the repo's `stylua.toml` — no changes required.
- Luacheck with the repo's `.luacheckrc` and `--std min --codes --ranges --no-cache` — 0 warnings, 0 errors.

### Notes

No docs change: this restores the documented meaning of `USE_CUSTOM_SSL` rather than altering it.

I did not add an integration test — `tests/core/customcert` is currently a single-service setup, and covering this would need a multisite scenario with generated wildcard certificates. Happy to add one if you'd like it, and equally happy to rework the approach: storing the wildcard certificate against its owning service instead of keeping an exclusion list would also solve it, and may fit the architecture better.
