### PR TITLE
fix(ui): remove CPU-heavy DataTables hover handler causing 100% CPU usage

### DIFF
--- a/src/ui/app/static/css/overrides.css
+++ b/src/ui/app/static/css/overrides.css
@@ -799,7 +799,11 @@ button.list-group-item-secondary.active {
 }
 
 table.dataTable tbody tr:hover > td {
-  background-color: rgba(var(--bs-primary-rgb), 0.1) !important;
+  background-color: rgba(var(--bs-primary-rgb), 0.1);
+}
+
+table.table.dataTable > tbody > tr.selected:hover > td {
+  background-color: rgba(var(--bs-primary-rgb), 0.16);
 }
 
 .text-bw-green {

--- a/src/ui/app/static/css/overrides.css
+++ b/src/ui/app/static/css/overrides.css
@@ -798,7 +798,7 @@ button.list-group-item-secondary.active {
   max-height: 60vh !important;
 }
 
-td.highlight {
+table.dataTable tbody tr:hover > td {
   background-color: rgba(var(--bs-primary-rgb), 0.1) !important;
 }
 

--- a/src/ui/app/static/js/dataTableInit.js
+++ b/src/ui/app/static/js/dataTableInit.js
@@ -584,31 +584,6 @@ function initializeDataTable(config) {
 
   if (dataTable.responsive) dataTable.responsive.recalc();
 
-  dataTable.on("mouseenter", "td", function () {
-    if (dataTable.cell(this).index() === undefined) return;
-    const rowIdx = dataTable.cell(this).index().row;
-
-    dataTable
-      .cells()
-      .nodes()
-      .each((el) => el.classList.remove("highlight"));
-
-    dataTable
-      .cells()
-      .nodes()
-      .each(function (el) {
-        if (dataTable.cell(el).index().row === rowIdx)
-          el.classList.add("highlight");
-      });
-  });
-
-  dataTable.on("mouseleave", "td", function () {
-    dataTable
-      .cells()
-      .nodes()
-      .each((el) => el.classList.remove("highlight"));
-  });
-
   dataTable.on("select", function (e, dt, type, indexes) {
     const actionButton = $(".action-button");
     if (!actionButton.length) return;


### PR DESCRIPTION
## Summary

- Removes the jQuery `mouseenter`/`mouseleave` delegated handlers in `dataTableInit.js` that ran a full `dataTable.cells().nodes().each()` scan over the entire table on every hover event, causing the JS thread to block and CPU usage to spike to 98-100% on any page with a large DataTable (reports, services, configs, plugins, jobs, instances, bans, templates, cache).
- Replaces the row-highlight-on-hover effect with a pure CSS rule (`table.dataTable tbody tr:hover > td`), which reproduces the same visual effect with zero JS execution per mouse movement.
- Since `initializeDataTable()` is shared by every page using a DataTable, this fix applies globally without any per-page changes.

## Test plan

- [V] Open the reports page with a large dataset and confirm CPU usage stays low while hovering over table rows
- [V] Confirm row hover highlight still visually works (background tint on the hovered row)
- [V] Spot-check hover highlight on at least one other DataTable page (e.g. services or configs)
- [V] Confirm row selection, sorting, and other DataTable interactions are unaffected
- [V] Docker image UI builded and tested on my live env

## Before / After (Firefox Performance profiler)

**Before (1.6.14)** — CPU pegged at 98-100% during mouse movement over the table (50 Rows):

<img width="790" height="312" alt="image" src="https://github.com/user-attachments/assets/ed4c39b6-3c5b-499f-ab56-337e46daad6c" />

**After** — CPU usage flat/idle during mouse movement over the table (50 Rows):

<img width="665" height="312" alt="image" src="https://github.com/user-attachments/assets/f9469bb8-4e2b-4ea6-9f4f-7c7366d22622" />